### PR TITLE
link to Cauldron.io

### DIFF
--- a/community-initiatives/untitled-4.md
+++ b/community-initiatives/untitled-4.md
@@ -41,7 +41,10 @@ When the CHAOSS community receives a request for a report, the following steps w
 
 ### 🍹 Generating visualizations from Cauldron
 
-Detailed steps for generating visualizations from [Cauldron](https://cauldron.io/) (step 5 above), follow these steps:
+Below are detailed steps for generating visualizations from [Cauldron](https://cauldron.io/) (step 5 above).
+
+_About Cauldron:_ 
+Cauldron is a Metrics as a Service platform, built on our CHAOSS GrimoireLab project, and can be used without installing anything.
 
 1. Receive an email from Vinod about (information 1:) which repository was requested, (information 2:) what time frame we are analyzing it for, and (information: 3) what Google Drive folder to store visualizations in.
 2. Open a new project in [Cauldron](https://cauldron.io/) for the requested repository (information 1) and wait until the data collection is complete (10 minutes to several hours).

--- a/community-initiatives/untitled-4.md
+++ b/community-initiatives/untitled-4.md
@@ -41,10 +41,10 @@ When the CHAOSS community receives a request for a report, the following steps w
 
 ### 🍹 Generating visualizations from Cauldron
 
-Detailed steps for generating visualizations from Cauldron (step 5 above), follow these steps:
+Detailed steps for generating visualizations from [Cauldron](https://cauldron.io/) (step 5 above), follow these steps:
 
-1. Receive an email from Vinod with information about (1) which repository was requested, (2) what time frame we are analyzing it for, and (3) what Google Drive folder to store visualizations in.
-2. Open a new project in Cauldron for the requested repository (information 1) and wait until the data collection is complete (10 minutes to several hours).
+1. Receive an email from Vinod about (information 1:) which repository was requested, (information 2:) what time frame we are analyzing it for, and (information: 3) what Google Drive folder to store visualizations in.
+2. Open a new project in [Cauldron](https://cauldron.io/) for the requested repository (information 1) and wait until the data collection is complete (10 minutes to several hours).
 3. Set the analysis time frame to the one indicated in Vinod's email (information 2).
 4. Make sure the browser is in full-screen size so that the visualizations have a consistent size when downloaded.
 5. Use the floppy disk symbol by the visualizations to download them. Navigate to visualizations:

--- a/community-initiatives/untitled-4.md
+++ b/community-initiatives/untitled-4.md
@@ -46,12 +46,12 @@ Below are detailed steps for generating visualizations from [Cauldron](https://c
 _About Cauldron:_ 
 Cauldron is a Metrics as a Service platform, built on our CHAOSS GrimoireLab project, and can be used without installing anything.
 
-1. Receive an email from Vinod about (information 1:) which repository was requested, (information 2:) what time frame we are analyzing it for, and (information: 3) what Google Drive folder to store visualizations in.
-2. Open a new project in [Cauldron](https://cauldron.io/) for the requested repository (information 1) and wait until the data collection is complete (10 minutes to several hours).
-3. Set the analysis time frame to the one indicated in Vinod's email (information 2).
+1. Receive an email from Vinod about (1) which repository was requested, (2) what time frame we are analyzing it for, and (3) what Google Drive folder to store visualizations in.
+2. Open a new project in [Cauldron](https://cauldron.io/) for the requested repository and wait until the data collection is complete (10 minutes to several hours).
+3. Set the analysis time frame to the one indicated in Vinod's email.
 4. Make sure the browser is in full-screen size so that the visualizations have a consistent size when downloaded.
 5. Use the floppy disk symbol by the visualizations to download them. Navigate to visualizations:
   1. Activity --> Commits --> # Number of commits by hour and weekday (local time of commit author)
   2. CHAOSS --> # Issues created/closed
-6. Upload the two visualizations to the Google Drive folder that Vinod created (information 3)
+6. Upload the two visualizations to the Google Drive folder that Vinod created.
 7. Reply to Vinod that the Cauldron visualizations are done


### PR DESCRIPTION
Add suggestions from #6: 1) link to cauldron.io; 2) clarify what "information 1" is.

Maybe we should remove the "information x" references; assuming the text is clear enough as is?

@ElizabethN, what do you think?
