### PR TITLE
Update heading for Continuous Contribution Process

### DIFF
--- a/community-initiatives/metrics/chaoss-metric-release.md
+++ b/community-initiatives/metrics/chaoss-metric-release.md
@@ -6,7 +6,7 @@ description: Details about releasing the metrics
 
 The version number is `YYYY-MM` of the release date. Continuous Metric Contributions do not get a separate version number.
 
-## Continuous Metric Contribution
+## Continuous Contribution Process
 
 The goal is to have short cycles of feedback and to get metrics out sooner.
 


### PR DESCRIPTION
The **Continuous Metric Contribution** name didn't make sense and was clunky to use. We decided on **Continuous Contribution Process**.

This PR updates the handbook heading