### PR TITLE
Slack Channel Newcomer Guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,6 +3,10 @@
 * [CHAOSS Community Handbook - Table of Contents](README.md)
 * [Handbook Usage](handbook-usage.md)
 
+## NEWCOMERS
+
+* [Newcomer's Quick Start Guide](newcomers/newcomers-guide.md)
+
 ## ABOUT
 
 * [CHAOSS History](about/chaoss-history.md)

--- a/badging/how-to-contribute.md
+++ b/badging/how-to-contribute.md
@@ -10,6 +10,13 @@ You can connect to us with the following methods:
 
 Please don’t hesitate to contact us by any of the means listed above when your thoughts about this project come up. Your suggestions are tremendously valuable to us. 
 
+#### Slack Channel and Usage Guidelines
+
+* We are okay with creating new channels as needed
+* When we archive minutes, we also archive inactive channels
+* Channels need to have meaningful names: use prefixes when possible to sort alphabetical list of channels (e.g., #GSOC21_projectname)
+
+
 ### Thank You
 
 Thank you so much for your interest in D&I badging program and wishing to make contributions. All kinds of contributions are appreciated.

--- a/newcomers/newcomers-guide.md
+++ b/newcomers/newcomers-guide.md
@@ -1,0 +1,8 @@
+# A Quick Start Guide for Newcomers
+
+There are three quick ways designed to meet, greet, encourage, and mentor newcomers to the CHAOSS Project. 
+1. Every week we have an office hours intended to make it easy for you to ask questions, and find your place in the project with a supportive, experienced CHAOSS maintainer. You can join these hours from 9am - 11am USA Central Time. [This is a link to our Zoom Channel](https://zoom.us/my/chaoss)
+2. We have a Slack Channel! And so many working group focused channels within it. BUT, we've reserved one ESPECIALLY for newcomers, and our community is highly responsive within it. This is the [Slack channel](https://chaoss-workspace.slack.com/join/shared_invite/zt-dqeab4ab-4XrH51rc4y_WXjN~uI~6rA#/). And THIS is the channel within a channel, called "#office-hours" where you'll be welcomed!  [Newcomers #office-hours channel in the CHAOSS Slack](https://chaoss-workspace.slack.com/archives/C0207C3RETX)
+3. Augur software has regular workshops to help you learn how to see what CHAOSS metrics show you about the projects you care about. You can learn about the date's and times by signing up for our mailing list/newsletter! 
+    - Mailing List: https://lists.linuxfoundation.org/mailman/listinfo/chaoss
+    - Newsletter on the Web: https://chaoss.community/news/ **We send one out every week thanks to the dedication of our Community Manager, Elizabeth Barron!


### PR DESCRIPTION
Added newcomer information related to the Slack Channel, mailing list, workshops, and Newsletter per community meeting on June 8, 2021.