### PR TITLE
Update details about GrimoireLab and added resources

### DIFF
--- a/contributing/development/README.md
+++ b/contributing/development/README.md
@@ -4,57 +4,79 @@ description: How to contribute through development
 
 # Development
 
-### ✏ Technical Requirements
+## 💾 Tech Stack
+
+* **GrimoireLab**: Python, Vue.js, JavaScript/TypeScript, MySQL, Django, GraphQL.
+* **Augur**: Python, Flask Vue.js, JavaScript/TypeScript, Jupyter.
+
+## ✏ Technical Requirements
 
 You'll need to have some basic programming experience with the technologies and tools we use.
 
-#### Tools
+### Tools
 
-* **Git & Github** - Clone, commit and open a PR using Git and GitHub. Check out the following tutorials:
+#### Git & GitHub
+  Clone, commit and open a PR using Git and GitHub. Check out the following tutorials:
   * [Introduction to git](https://www.freecodecamp.org/news/what-is-git-and-how-to-use-it-c341b049ae61/)
   * [Introduction to GitHub](https://product.hubspot.com/blog/git-and-github-tutorial-for-beginners)
   * [Popular git commands and how to use them](https://rogerdudler.github.io/git-guide/)
   * [Git commands in-depth](https://medium.com/@george.seif94/a-full-tutorial-on-how-to-use-github-88466bac7d42)
   * [Mastering Markdown](https://guides.github.com/features/mastering-markdown/)
   * [Markdown Tutorial](https://www.markdowntutorial.com/)
+  * [How to Write a Git Commit Message](htthttps://www.fullstackpython.com/django.htmlps://chris.beams.io/posts/git-commit/)
 
-#### languages
+### Languages and Frameworks
 
-* **Python Guides** 
+#### Python
   * [Python's official tutorial](https://docs.python.org/3/tutorial/index.html)
   * [Python's official style guide](https://www.python.org/dev/peps/pep-0008/)
   * [Python's best practices](https://gist.github.com/sloria/7001839)
   * [The Zen of Python](https://www.python.org/dev/peps/pep-0020/)
 
-### 🏗 Project Structure
+#### Flask
+  * [Quickstart — Flask Documentation (2.0.x)](https://flask.palletsprojects.com/en/2.0.x/quickstart/)
+  * [Flask - Full Stack Python](https://www.fullstackpython.com/flask.html)
+
+#### Django
+  * [Getting started with Django | Django](https://www.djangoproject.com/start/)
+  * [Django Girls Tutorial](https://tutorial.djangogirls.org/en/)
+  * [Django - Full Stack Python](https://www.fullstackpython.com/django.html)
+
+#### Vue.js
+  * [Introduction — Vue.js](https://vuejs.org/v2/guide/)
+
+## 🏗 Project Structure
 
 The CHAOSS community's projects have been divided in the following ways:
 
-* **Grimoirelab**
-  * [**chaoss / grimoirelab** ](https://github.com/chaoss/grimoirelab)**-** It contains the details of the grimoirelab modules
-  * [**chaoss / grimoirelab-elk**](https://github.com/chaoss/grimoirelab-elk) - GrimoireELK is the component that interacts with the ElasticSearch database.
-  * [**chaoss / grimoirelab-sigils**](https://github.com/chaoss/grimoirelab-sigils) - These are panels from GrimoireLab dashboards
-  * [**chaoss / grimoirelab-sortinghat**](https://github.com/chaoss/grimoirelab-sortinghat) - Sorting Hat maintains an SQL database of unique identities of community members across \(potentially\) many different sources.
-  * \*\*\*\*[**chaoss / grimoirelab-sirmordred**](https://github.com/chaoss/grimoirelab-sirmordred) ****- Orchestrate the execution of GrimoireLab tools to produce a dashboard
-  * \*\*\*\*[**chaoss / grimoirelab-perceval**](https://github.com/chaoss/grimoirelab-perceval) - Send Sir Perceval on a quest to retrieve and gather data from software repositories.
-  * \*\*\*\*[**chaoss / grimoirelab-tutorial**](https://github.com/chaoss/grimoirelab-tutorial) -  This repository contains the tutorials for the grimoirelab project
-  * \*\*\*\*[**chaoss / grimoirelab-hatstall**](https://github.com/chaoss/grimoirelab-hatstall) **-**  Hatstall is a web interface for [SortingHat](http://github.com/grimoirelab/sortinghat) databases developed mainly with [Django](https://www.djangoproject.com/) 
-  * \*\*\*\*[**chaoss / grimoirelab-toolkit**](https://github.com/chaoss/grimoirelab-toolkit) - Toolkit of common functions used across GrimoireLab projects.
-  * \*\*\*\*[**chaoss / grimoirelab-cereslib**](https://github.com/chaoss/grimoirelab-cereslib) **-** Ceres is a library that aims at dealing with data in general, and software development data in particular.
-  * \*\*\*\*[**chaoss / grimoirelab-kidash**](https://github.com/chaoss/grimoirelab-kidash) - Kidash is a tool for managing Kibana-related dashboards from the command line. 
-  * [**chaoss / grimoirelab-graal**](https://github.com/chaoss/grimoirelab-graal) **-** Graal leverages on the Git backend of Perceval and enhances it to set up ad-hoc source code analysis.
-  * \*\*\*\*[**chaoss / grimoirelab-kibiter**](https://github.com/chaoss/grimoirelab-kibiter) - 
-  * \*\*\*\*[**chaoss / grimoirelab-bestiary**](https://github.com/chaoss/grimoirelab-bestiary) - A tool to visually manage software development ecosystems description.
-  * \*\*\*\*[**chaoss / grimoirelab-manuscripts**](https://github.com/chaoss/grimoirelab-manuscripts) - 
-  * \*\*\*\*[**chaoss / grimoirelab-kingarthur**](https://github.com/chaoss/grimoirelab-kingarthur) - King Arthur commands his loyal knight Perceval on the quest to retrieve data from software repositories.
-  * \*\*\*\*[**chaoss / grimoirelab-perceval-puppet** ](https://github.com/chaoss/grimoirelab-perceval-puppet)Bundle of Perceval backends for Puppet, Inc. ecosystem.
-  * \*\*\*\*[**chaoss / grimoirelab-perceval-mozilla**](https://github.com/chaoss/grimoirelab-perceval-mozilla) - Bundle of Perceval backends for Mozilla ecosystem.
-  * \*\*\*\*[**chaoss / grimoirelab-perceval-opnfv**](https://github.com/chaoss/grimoirelab-perceval-opnfv) **-** Bundle of Perceval backends for OPNFV ecosystem.
-* **Augur**
-  * \*\*\*\*[**chaoss / augur**](https://github.com/chaoss/augur) **-**  Augur is a tool for collecting and measuring structured data about [free](https://www.fsf.org/about/) and [open source](https://opensource.org/docs/osd) \(FOSS\) communities.
-  * \*\*\*\*[**chaoss / augur-spdx**](https://github.com/chaoss/augur-spdx) **-** Augur's Open Source License coverage tool. Provides license identification by file, identification of non-OSI compliant licenses, and percentage of a project with license declarations.
-  * \*\*\*\*[**chaoss / augur-auggie**](https://github.com/chaoss/augur-auggie) **-** Auggie implementation utilizing Amazon Lex to classify messages.
-  * \*\*\*\*[**chaoss / augur-community-reports**](https://github.com/chaoss/augur-community-reports) - A set of Jupyter Lab Notebooks and Other Implementations of Community Reports in Standard Form
-* **Cregit**
-  * \*\*\*\*[**cregit / cregit**](https://github.com/cregit/cregit) **-**
+### GrimoireLab
 
+* [**chaoss / grimoirelab**](https://github.com/chaoss/grimoirelab): The main repository for the GrimoireLab project, contains the information and details of all the tools.
+* [**chaoss/grimoirelab-tutorial**](https://github.com/chaoss/grimoirelab-tutorial): Tutorial and guides for GrimoireLab.
+
+* Data retrieval related components:
+  * [**chaoss / grimoirelab-perceval**](https://github.com/chaoss/grimoirelab-perceval): Retrieval of data from data sources.
+  * [**chaoss / grimoirelab-graal**](https://github.com/chaoss/grimoirelab-graal): Source data analysis with external tools.
+  * [**chaoss / grimoirelab-kingarthur**](https://github.com/chaoss/grimoirelab-kingarthur): Batch processing for massive retrieval.
+* Data enrichment related components:
+  * [**chaoss / grimoirelab-elk**](https://github.com/chaoss/grimoirelab-elk): Storage and enrichment of data.
+  * [**chaoss / grimoirelab-cereslib**](https://github.com/chaoss/grimoirelab-cereslib): Generic data processor.
+  * [**chaoss / grimoirelab-sortinghat**](https://github.com/chaoss/grimoirelab-sortinghat): Identity management.
+* Data consumption related components:
+  * [**chaoss / grimoirelab-kibiter**](https://github.com/chaoss/grimoirelab-kibiter): Dashboard, downstream version of Kibana.
+  * [**chaoss / grimoirelab-sigils**](https://github.com/chaoss/grimoirelab-sigils): Visualizations and dashboards.
+  * [**chaoss / grimoirelab-kidash**](https://github.com/chaoss/grimoirelab-kidash): Visualizations and dashboards manager.
+  * [**chaoss / grimoirelab-manuscripts**](https://github.com/chaoss/grimoirelab-manuscripts): Reporting.
+* Platform management, orchestration, and common utils:
+  * [**chaoss / grimoirelab-mordred**](https://github.com/chaoss/grimoirelab-mordred): Orchestration.
+  * [**chaoss / grimoirelab-toolkit**](https://github.com/chaoss/grimoirelab-toolkit): Common utilities.
+  * [**chaoss / grimoirelab-bestiary**](https://github.com/chaoss/grimoirelab-bestiary): Web-based user interface to manage repositories and projects for Mordred.
+
+### Augur
+  * [**chaoss / augur**](https://github.com/chaoss/augur): Augur is a tool for collecting and measuring structured data about [free](https://www.fsf.org/about/) and [open source](https://opensource.org/docs/osd) \(FOSS\) communities.
+  * [**chaoss / augur-spdx**](https://github.com/chaoss/augur-spdx): Augur's Open Source License coverage tool. Provides license identification by file, identification of non-OSI compliant licenses, and percentage of a project with license declarations.
+  * [**chaoss / augur-auggie**](https://github.com/chaoss/augur-auggie): Auggie implementation utilizing Amazon Lex to classify messages.
+  * [**chaoss / augur-community-reports**](https://github.com/chaoss/augur-community-reports): A set of Jupyter Lab Notebooks and Other Implementations of Community Reports in Standard Form.
+
+### Cregit
+  * [**cregit / cregit**](https://github.com/cregit/cregit): Cregit is a framework of tools that facilitates the analysis and visualization of the evolution of source code stored in git repositories.

--- a/contributing/development/contributing-worfkflow.md
+++ b/contributing/development/contributing-worfkflow.md
@@ -35,11 +35,14 @@ $ cd augur/
 
 This is the step where you make desired changes to the codebase inside the respective repository.
 
+Writing a well-crafted Git commit message is the best way to communicate context about a change to fellow developers. Seven rules of a great Git commit message are mentioned in [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
+
 ### Sending Pull Request
 
 After you have made the desired changes into your fork version of the repository, you are required to send the pull request with the description explaining your changes. [**Checkout Github guide to creating the Pull Request**](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)\*\*\*\*
 
 At this point, you're waiting on us. We like to at least comment on pull requests within three business days \(and, typically, one business day\). Once one of our maintainers has had a chance to review your PR, we will either mark it as "needs review" and provide specific feedback on your changes, or we will go ahead and complete the pull request.
 
-We require all commits to be signed off with a [Developer Certificate of Origin](https://developercertificate.org/) in accordance with the [CHAOSS charter](https://chaoss.community/about/charter/#user-content-8-intellectual-property-policy). This can be easily done by using the `-s` flag when using `git commit`. For example: `git commit -s -m "Update README.md"`. **Any pull requests containing commits that are not signed off will not be eligible for merge until the commits have been signed off.**
+We require all commits to be signed off with a [Developer Certificate of Origin](https://developercertificate.org/) in accordance with the [CHAOSS charter](https://chaoss.community/about/charter/#user-content-8-intellectual-property-policy). This can be easily done by using the `-s` flag when using `git commit`. For example: `git commit -s -m "Update README.md"`. This can be automated by using a browser plugin like [DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui).
 
+**NOTE**: Any pull requests containing commits that are not signed off will not be eligible for merge until the commits have been signed off.


### PR DESCRIPTION
This PR updates the development page with the grimoirelab details and the list of projects. It also adds the tech stack for the projects and a few resources for learning them.

Added resources & information about writing a good commit message and link for DCO sign-off browser plugin.

It also formats the content to align to a particular style.

Related to https://github.com/chaoss/grimoirelab/issues/391