### PR TITLE
Updates made to outreachy.md

### DIFF
--- a/mentorships/outreachy.md
+++ b/mentorships/outreachy.md
@@ -1,10 +1,11 @@
 # Outreachy
 
-## About Outreachy ![](../.gitbook/assets/outreachy-logo.png) 
+## About Outreachy
+![Outreachy logo](../.gitbook/assets/outreachy-logo.png)
 
 Outreachy is a paid, remote internship program. Outreachy's goal is to support people from groups underrepresented in tech. They help newcomers to free software and open-source make their first contributions.
 
-Outreachy provides internships to work open source. People apply from all around the world. Interns work remotely and are not required to move. Interns are paid a stipend of $5,500 USD for the three-month internship. Interns have a $500 USD travel stipend to attend conferences or events.
+Outreachy provides internships to work open source. People apply from all around the world. Interns work remotely and are not required to move. Interns are paid a stipend of **$7,000** 🤑💰
 
 Interns work with experienced mentors from open source communities. Outreachy internship projects may include programming, user experience, documentation, illustration, graphical design, or data science. Interns often find employment after their internship with Outreachy sponsors or in jobs that use the skills they learned during their internship.
 
@@ -14,16 +15,14 @@ Interns work with experienced mentors from open source communities. Outreachy in
 
 ## **Outreachy Eligibility Rules** ✔ 
 
-{% hint style="info" %}
-**NOTE:** These eligibility rules are exactly the same and have been taken from the ****[**Outreachy official website**](https://www.outreachy.org/docs/applicant/#what-is-outreachy)\*\*\*\*
-{% endhint %}
+> :information_source: **NOTE:** These eligibility rules are exactly the same and have been taken from the [**Outreachy official website**](https://www.outreachy.org/docs/applicant/#what-is-outreachy)
 
-These eligibility rules apply to December 2020 to March 2021 Outreachy internships round. Dates may change for future rounds.
+These eligibility rules apply to May 2022 to August 2022 Outreachy internships round. Dates may change for future rounds.
 
 Outreachy is open to applicants around the world. You will need to meet the following requirements:
 
-* You are or will be 18 years of age or older by Dec. 1, 2020
-* You are available for a full-time, 40 hours a week internship from Dec. 1, 2020**,** to March 2, 2021.
+* You are or will be 18 years of age or older by May 2022.
+* You are available for a full-time, 40 hours a week internship from **Late May 2022**, **to Late August 2022.**
 * You were not an intern with Outreachy, the Outreach Program for Women, or Google Summer of Code. People who were a Google Summer of Code intern are not eligible for Outreachy. All Google Summer of Code interns are ineligible for Outreachy, including people who did not successfully finish their GSoC internship. If you apply to Outreachy and you are not accepted as an intern, you may apply again.
 * Applicants who have part-time or contracting jobs are welcome to apply. People who are willing to quit their full-time job are welcome to apply. If you cannot quit your full-time job, you are not eligible for Outreachy. People who are taking a leave of absence from a full-time job are not eligible for Outreachy.
 * Outreachy is open to both university students and people who are not university students. University students must have 42 consecutive days free from school and exams during the internship period. Students must apply to the correct internship round \(see rules below\).
@@ -44,10 +43,10 @@ Outreachy internships run twice a year, May to August and December to March. We 
 | :---: | :---: | :---: |
 | Initial application opens | late January | late Agust |
 | Initial applications due | end of February | end of September |
-| Contribution period opens | March | October |
-| Final application and contributions due | April | November |
+| Contribution period opens | late March | late October |
+| Final application and contributions due | late April | late November |
 | Interns announced | May | November |
-| Internships start | May | December |
+| Internships start | early May | early December |
 | Internships end | August | March |
 
 ## Expectations
@@ -72,7 +71,6 @@ Outreachy internships run twice a year, May to August and December to March. We 
 * **Guidance** to interns about time management.
 * **Holds fair knowledge of the project** you are mentoring.
 
-{% hint style="warning" %}
-**Source Citation:** [**Outreachy Internship Guide**](https://www.outreachy.org/docs/internship/#mentor-expectations)**,** [**Outreachy Applicant Guide**](https://www.outreachy.org/docs/applicant/)**,** and ****[**Outreachy Official Website**](https://www.outreachy.org/)\*\*\*\*
-{% endhint %}
+
+> ⚠️ **Source Citation: [Outreachy Internship Guide](https://www.outreachy.org/docs/internship/#mentor-expectations)**, [**Outreachy Applicant Guide**](https://www.outreachy.org/docs/applicant/)**, and [**Outreachy Official Website**](https://www.outreachy.org/)
 


### PR DESCRIPTION
Going through the Chaoss documentation noticed some few outdated content to the documentation part concerning Outreachy. Did some minor improvements to that content.
Some of these modifications included
- The internship correct dates or periods
-  The actual price of the stipend for this current year
-  The hints which were not supported, I migrated them  to a  better form